### PR TITLE
Fix file creation + file opening + dirs and everything

### DIFF
--- a/src/main/kotlin/ru/nsu_null/npide/ui/filetree/FileDialog.kt
+++ b/src/main/kotlin/ru/nsu_null/npide/ui/filetree/FileDialog.kt
@@ -18,13 +18,13 @@ import java.io.File as ioFile
 
 @ExperimentalComposeUiApi
 @Composable
-fun SimpleOutlinedTextFieldSample(): String {
+fun OutlineFieldItemNameGetter(): String {
     var text by remember { mutableStateOf("") }
 
     OutlinedTextField(
         value = text,
         onValueChange = { text = it },
-        label = { Text("Filename", fontWeight = FontWeight.Bold, color = Color.Black) },
+        label = { Text("Item name", fontWeight = FontWeight.Bold, color = Color.Black) },
         textStyle = TextStyle(color = Color.Black, fontWeight = FontWeight.Bold),
         modifier = Modifier.padding(20.dp),
         colors = TextFieldDefaults.outlinedTextFieldColors(
@@ -36,42 +36,40 @@ fun SimpleOutlinedTextFieldSample(): String {
     return text
 }
 
-fun FileCreate(fileName: String) {
-    val file = ioFile(fileName)
-    file.writeBytes(ByteArray(0))
-
-}
-
+/**
+ * In fact is a blocking call to receive a file name
+ * @return a name of an item (Folder or File) to create. NOTE: this is not a full path to it
+ */
 @ExperimentalComposeUiApi
 @Composable
-fun OpenCreteFileDialog(state: MutableState<Boolean>, filepath: String) {
+fun CreateItemDialog(onCloseRequest: () -> Unit): String? {
 // TODO добавить Enter
-    Dialog(onCloseRequest = { state.value = false }) {
-        val text = SimpleOutlinedTextFieldSample()
+    var fileName: String? by remember { mutableStateOf(null) }
+    Dialog(onCloseRequest = onCloseRequest,
+        title = "Choose new item name") {
+        val text = OutlineFieldItemNameGetter().ifBlank { null }
         Button(
             onClick = {
-                val filename = "$filepath/$text"
-                println(filename)
-                FileCreate(filename)
-                state.value = false
+                fileName = text
             },
             modifier = Modifier.padding(120.dp)
         ) {
-            Text("ok")
-
+            Text("Create")
         }
-
     }
+    return fileName
 }
 
 
 @ExperimentalComposeUiApi
 @Composable
-fun OpenDeleteDialog(state: MutableState<Boolean>, filepath: String) {
+fun DeleteItemDialog(onCloseRequest: () -> Unit, fullFileName: String): Boolean {
 // TODO Enter
-    Dialog(onCloseRequest = { state.value = false }, title = "Warning") {
+    var userAnswer by remember { mutableStateOf(false) }
+    Dialog(onCloseRequest = onCloseRequest, title = "Delete file?") {
+        val buttonModifier = Modifier.padding(60.dp, 100.dp)
         Text(
-            text = "Are you sure want to delete $filepath?",
+            text = "Are you sure you want to delete $fullFileName?",
             modifier = Modifier.padding(60.dp, 40.dp),
             color = Color.Black,
             fontSize = 12.sp
@@ -79,31 +77,30 @@ fun OpenDeleteDialog(state: MutableState<Boolean>, filepath: String) {
         Row {
             Button(
                 onClick = {
-                    FileDelete(filepath)
-                    state.value = false
+                    userAnswer = true
+                    onCloseRequest()
                 },
-                modifier = Modifier.padding(60.dp, 100.dp)
+                modifier = buttonModifier
             ) {
-                Text("Ok")
-
+                Text("Delete file")
             }
             Button(
                 onClick = {
-                    state.value = false
+                    userAnswer = false
+                    onCloseRequest()
                 },
-                modifier = Modifier.padding(60.dp, 100.dp)
+                modifier = buttonModifier
             ) {
                 Text("Cancel")
-
             }
         }
 
     }
+    return userAnswer
 }
 
-fun FileDelete(fileName: String) {
+fun deleteFile(fileName: String) {
     val file = ioFile(fileName)
     if (file.exists())
         file.deleteRecursively()
 }
-

--- a/src/main/kotlin/ru/nsu_null/npide/ui/filetree/FileTreeView.kt
+++ b/src/main/kotlin/ru/nsu_null/npide/ui/filetree/FileTreeView.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.isPrimaryPressed
 import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.pointerMoveFilter
@@ -179,15 +180,17 @@ fun FileTreeDropDownMenu(expanded: Boolean, onDismissRequest: () -> Unit, model:
 
 @Composable
 private fun FileItemIcon(modifier: Modifier, model: FileTree.Item) = Box(modifier.size(24.dp).padding(4.dp)) {
+    @Composable
+    fun dirIcon(icon: ImageVector) = Icon(
+        icon,
+        contentDescription = null,
+        tint = LocalContentColor.current
+    )
     when (val type = model.type) {
         is FileTree.ItemType.Folder -> when {
-            !type.canExpand -> Unit
-            type.isExpanded -> Icon(
-                Icons.Default.KeyboardArrowDown, contentDescription = null, tint = LocalContentColor.current
-            )
-            else -> Icon(
-                Icons.Default.KeyboardArrowRight, contentDescription = null, tint = LocalContentColor.current
-            )
+            !type.canExpand -> dirIcon(Icons.Default.FolderSpecial)
+            type.isExpanded -> dirIcon(Icons.Default.FolderOpen)
+            else -> dirIcon(Icons.Default.Folder)
         }
         is FileTree.ItemType.File -> when (type.ext) {
             "clj" -> Icon(Icons.Default.Code, contentDescription = null, tint = Color(0xFF3E86A0))

--- a/src/main/kotlin/ru/nsu_null/npide/ui/filetree/FileTreeView.kt
+++ b/src/main/kotlin/ru/nsu_null/npide/ui/filetree/FileTreeView.kt
@@ -1,24 +1,25 @@
 package ru.nsu_null.npide.ui.filetree
 
-import androidx.compose.foundation.ContextMenuDataProvider
-import androidx.compose.foundation.ContextMenuItem
+import CreateItemDialog
+import DeleteItemDialog
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.MouseClickScope
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.mouseClickable
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.pointerMoveFilter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
@@ -27,6 +28,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ru.nsu_null.npide.platform.VerticalScrollbar
+import ru.nsu_null.npide.ui.common.AppTheme
 import ru.nsu_null.npide.util.withoutWidthConstraints
 
 @Composable
@@ -78,63 +80,98 @@ fun FileTreeView(model: FileTree) = Surface(
 @ExperimentalFoundationApi
 @Composable
 private fun FileTreeItemView(fontSize: TextUnit, height: Dp, model: FileTree.Item) {
-    val stateCreate = remember { mutableStateOf(false) }
-    val stateRemove = remember { mutableStateOf(false) }
 
+    var showContextMenu by remember { mutableStateOf(false) }
+
+    val mouseClickHandler: MouseClickScope.() -> Unit = {
+        if (buttons.isPrimaryPressed) model.open()
+        if (buttons.isSecondaryPressed) showContextMenu = true
+    }
     Row(
         modifier = Modifier
             .wrapContentHeight()
-            .combinedClickable(
-                onClick = { model.open() },
-
-
-                )
+            .mouseClickable(onClick = mouseClickHandler)
             .padding(start = 24.dp * model.level)
             .height(height)
             .fillMaxWidth()
     ) {
-        if (stateCreate.value) {
-            model.createFile(stateCreate)
-        } else if (stateRemove.value) {
-            model.removeFile(stateRemove)
-        }
-        val active = remember { mutableStateOf(false) }
-
+        FileTreeDropDownMenu(
+            expanded = showContextMenu,
+            onDismissRequest = { showContextMenu = false },
+            model = model
+        )
         FileItemIcon(Modifier.align(Alignment.CenterVertically), model)
+
         MaterialTheme {
-            ContextMenuDataProvider(
-                items = {
-                    listOf(
-                        ContextMenuItem("Create File") { stateCreate.value = true },
-                        ContextMenuItem("Delete") { stateRemove.value = true },
-                    )
-                }
+            val active = remember { mutableStateOf(false) }
+            Text(
+                text = model.name,
+                color = if (active.value) LocalContentColor.current.copy(alpha = 0.60f) else LocalContentColor.current,
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .clipToBounds()
+                    .pointerMoveFilter(
+                        onEnter = {
+                            active.value = true
+                            true
+                        },
+                        onExit = {
+                            active.value = false
+                            true
+                        }
+                    ),
+                softWrap = true,
+                fontSize = fontSize,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
             )
-            {
-                SelectionContainer {
-                    Text(
-                        text = model.name,
-                        color = if (active.value) LocalContentColor.current.copy(alpha = 0.60f) else LocalContentColor.current,
-                        modifier = Modifier
-                            .align(Alignment.CenterVertically)
-                            .clipToBounds()
-                            .pointerMoveFilter(
-                                onEnter = {
-                                    active.value = true
-                                    true
-                                },
-                                onExit = {
-                                    active.value = false
-                                    true
-                                }
-                            ),
-                        softWrap = true,
-                        fontSize = fontSize,
-                        overflow = TextOverflow.Ellipsis,
-                        maxLines = 1
-                    )
-                }
-            }
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun FileTreeDropDownMenu(expanded: Boolean, onDismissRequest: () -> Unit, model: FileTree.Item) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier.background(AppTheme.colors.backgroundLight)
+    ) {
+        var showCreateFileDialog by remember { mutableStateOf(false) }
+        val fileToCreate = if (showCreateFileDialog) CreateItemDialog(onCloseRequest = onDismissRequest) else null
+        fileToCreate?.let {
+            model.addItem(it, FileTree.ActionType.CreateFile)
+            showCreateFileDialog = false
+            onDismissRequest()
+        }
+
+        var showCreateFolderDialog by remember { mutableStateOf(false) }
+        val folderToCreate = if (showCreateFolderDialog) CreateItemDialog(onCloseRequest = onDismissRequest) else null
+        folderToCreate?.let {
+            model.addItem(it, FileTree.ActionType.CreateFolder)
+            showCreateFolderDialog = false
+            onDismissRequest()
+        }
+
+        var showDeleteFileDialog by remember { mutableStateOf(false) }
+        val deleteFile: Boolean = if (showDeleteFileDialog) {
+            DeleteItemDialog(onCloseRequest = onDismissRequest, fullFileName = model.name)
+        } else false
+        if (deleteFile) {
+            model.removeItem()
+            showDeleteFileDialog = false
+            onDismissRequest()
+        }
+
+        // NOTE(Roman Brek) could probably come up with better design to dry this up
+        DropdownMenuItem(onClick = { showCreateFileDialog = true }) {
+            Text("Create file")
+        }
+        DropdownMenuItem(onClick = { showCreateFolderDialog = true }) {
+            Text("Create directory")
+        }
+        DropdownMenuItem(onClick = { showDeleteFileDialog = true }) {
+            Text("Delete item")
         }
     }
 }
@@ -153,6 +190,7 @@ private fun FileItemIcon(modifier: Modifier, model: FileTree.Item) = Box(modifie
             )
         }
         is FileTree.ItemType.File -> when (type.ext) {
+            "clj" -> Icon(Icons.Default.Code, contentDescription = null, tint = Color(0xFF3E86A0))
             "kt" -> Icon(Icons.Default.Code, contentDescription = null, tint = Color(0xFF3E86A0))
             "xml" -> Icon(Icons.Default.Code, contentDescription = null, tint = Color(0xFFC19C5F))
             "txt" -> Icon(Icons.Default.Description, contentDescription = null, tint = Color(0xFF87939A))
@@ -160,6 +198,8 @@ private fun FileItemIcon(modifier: Modifier, model: FileTree.Item) = Box(modifie
             "gitignore" -> Icon(Icons.Default.BrokenImage, contentDescription = null, tint = Color(0xFF87939A))
             "gradle" -> Icon(Icons.Default.Build, contentDescription = null, tint = Color(0xFF87939A))
             "kts" -> Icon(Icons.Default.Build, contentDescription = null, tint = Color(0xFF3E86A0))
+            "yaml" -> Icon(Icons.Default.Settings, contentDescription = null, tint = Color(0xFF62B543))
+            "config" -> Icon(Icons.Default.Settings, contentDescription = null, tint = Color(0xFF62B543))
             "properties" -> Icon(Icons.Default.Settings, contentDescription = null, tint = Color(0xFF62B543))
             "bat" -> Icon(Icons.Default.Launch, contentDescription = null, tint = Color(0xFF87939A))
             else -> Icon(Icons.Default.TextSnippet, contentDescription = null, tint = Color(0xFF87939A))


### PR DESCRIPTION
Раньше:
 - Выбор файла / expanding папки срабатывал только по нажатию на иконку. Нажатие на текст игнорировалось
 - Можно создавать файлы в текущей директории
 - Созданные файлы отображались только после ручного обновления дерева

Теперь:
 - Общего рода рефакторинг:
   - Убрал `@Composable` методы из `FileTree.Item` 
   - Обновил попап на новый
   - прочее
 - Теперь снова можно кликать на название папки/файла, а не на его иконку (пкм все еще работает)
 - Можно создавать файл:
   - Как сосед данного файла, если нажатие было на файл
   - Как вложенный файл, если нажатие было на папку
   - При создании файла в папке папка открывается
   - При создании файла как соседа файл показывается сразу
 - Удаление файлов и папок (дерево обновляется сразу)
 - Создание папки (логика такая же, как для создания файла)

Из минусов:
 - Добавил метод `getParent()` для `FileTree.Item`. Работать на больших деревьях он будет медленно, O(n) от количества всех файлов в дереве. Связано с изначально прибывшей к нам архитектурой этого дерева, которая оптимизировала то ли память, то ли избегала pointer-chasing, ибо хранит она вместо дерева список с уровнями вложенности